### PR TITLE
Make library work on non-Linux unices

### DIFF
--- a/iconv.lisp
+++ b/iconv.lisp
@@ -17,7 +17,7 @@
 
 (cffi:define-foreign-library libiconv
   (:darwin "libiconv.dylib")
-  (:unix "libiconv.so"))
+  ((and :unix (not :linux)) "libiconv.so"))
 
 (cffi:use-foreign-library libiconv)
 


### PR DESCRIPTION
libiconv.so is integrated in libc on linux, but other Unix operating systems do not do this. This foreign library definition will accommodate this.
