### PR TITLE
Make minimum size of the output buffer 100 bytes

### DIFF
--- a/iconv.lisp
+++ b/iconv.lisp
@@ -101,7 +101,7 @@ Previous ~a bytes leading up to this error: ~s"
 (defun iconv (from-code to-code from-vector)
   (with-iconv-cd (cd from-code to-code)
     (let* ((in-len (length from-vector))
-	   (out-len (* in-len 2))
+	   (out-len (max (* in-len 2) 100))
 	   (out (make-array out-len
 			    :element-type '(unsigned-byte 8)
 			    :fill-pointer 0


### PR DESCRIPTION
Under some circumstances iconv can fail if the buffer is too small,
even if it's big enough to contain the entire output data. Specifically,
this happens if the output data is one byte, and the output buffer is
two bytes in size. This would read to an infinite loop where CL-ICONV
would keep trying to call iconv with the same arguments.

This fix makes sure the output buffer is never smaller than 100 bytes,
which will prevent this problem from happening.
